### PR TITLE
Load http_archive and git_repository from Bazel tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     addons:
       apt:
         sources:
-          - llvm-toolchain-trusty-4.0
+          - llvm-toolchain-xenial-4.0
         packages:
           - clang-format-4.0
     script:
@@ -60,7 +60,7 @@ matrix:
   #   addons:
   #     apt:
   #       sources:
-  #         - llvm-toolchain-trusty-4.0
+  #         - llvm-toolchain-xenial-4.0
   #       packages:
   #         - clang-4.0
   #         - clang-tidy-4.0
@@ -168,7 +168,7 @@ matrix:
     addons:
       apt:
         sources:
-          - llvm-toolchain-trusty-4.0
+          - llvm-toolchain-xenial-4.0
         packages:
           - clang-4.0
     script:
@@ -186,7 +186,7 @@ matrix:
     addons:
       apt:
         sources:
-          - llvm-toolchain-trusty-5.0
+          - llvm-toolchain-xenial-5.0
         packages:
           - clang-5.0
     script:
@@ -205,7 +205,7 @@ matrix:
       apt:
         sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-6.0
+          - llvm-toolchain-xenial-6.0
         packages:
           - clang-6.0
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: cpp
 
 # Install Bazel and cppcheck.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python
   - sudo add-apt-repository -y ppa:webupd8team/java
-  - sudo apt-get update && sudo apt-get install oracle-java8-installer
+  - sudo apt-get update && sudo apt-get install openjdk-8-jdk
   - sudo echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
   - curl https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg | sudo apt-key add -
   - sudo apt-get update && sudo apt-get install bazel

--- a/README.md
+++ b/README.md
@@ -69,20 +69,18 @@ int main(int argc, char** argv) {
 
 ## Building
 
-[Bazel](https://bazel.build/) is used to build `tally-cpp`. In addition to Bazel, `tally-cpp`
-also requires GNU build tools:
+[Bazel] is used to build `tally-cpp`. In addition to Bazel, `tally-cpp` also requires GNU build
+tools:
 
-  - autoconf 2.65
-  - automake 1.13
-  - libtool 1.5.24
+- autoconf 2.65
+- automake 1.13
+- libtool 1.5.24
 
-This requirement stems from the fact that `tally-cpp` depends on
-[Apache thrift](https://github.com/apache/thrift) for the default reporter implementation. Thrift
-uses CMake as its build system and has some pre-build steps which generate necessary header
-files. We use Bazel's [`repository_rules`](https://docs.bazel.build/versions/master/skylark/repository_rules.html)
-feature to ensure these pre-build commands are run after fetching the Thrift source code, following
-the approach taken by Envoy and discussed in
-[this blog post](https://blog.envoyproxy.io/external-c-dependency-management-in-bazel-dd37477422f5).
+This requirement stems from the fact that `tally-cpp` depends on [Apache thrift] for the default
+reporter implementation. Thrift uses CMake as its build system and has some pre-build steps which
+generate necessary header files. We use Bazel's [`repository_rules`] feature to ensure these
+pre-build commands are run after fetching the Thrift source code, following the approach taken by
+Envoy and discussed in [this blog post].
 
 To use tally in your project you'll need to first at it as a dependency to your project. First
 add the following to your `WORKSPACE` file:
@@ -108,9 +106,9 @@ boost_deps()
 When you call `tally_cpp_repositories()` in your WORKSPACE file you'll introduce the following
 dependencies to your project:
 
-  - `load_com_google_googletest()` for Google gtest
-  - `load_com_github_nelhage_rules_boost()` for Boost
-  - `load_org_apache_thrift()` for Apache Thrift
+- `load_com_google_googletest()` for Google gtest
+- `load_com_github_nelhage_rules_boost()` for Boost
+- `load_org_apache_thrift()` for Apache Thrift
 
 In addition, you also need to load and call `boost_deps()` to add the necessary boost libraries.
 
@@ -132,16 +130,22 @@ cc_binary(
 
 To check out the repo and build the library:
 
-```
+```bash
 bazel build //...     # build everything
 bazel build //tally   # build just the tally library
 ```
 
 To run the unit tests:
 
-```
+```bash
 bazel test //...            # run all unit tests
 bazel test //m3/tests:unit  # run just the m3 tests
 ```
 
 We try to adhere to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
+
+[Bazel]: https://bazel.build/
+[Apache thrift]: https://github.com/apache/thrift
+[`repository_rules`]: https://docs.bazel.build/versions/master/skylark/repository_rules.html
+[this blog post]: https://blog.envoyproxy.io/external-c-dependency-management-in-bazel-dd37477422f5
+[Google C++ Style Guide]: https://google.github.io/styleguide/cppguide.html

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ add the following to your `WORKSPACE` file:
 ```python
 workspace(name = "com_github_jeromefroe_tally_cpp_example")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "com_github_m3db_tally_cpp",
     strip_prefix = "tally-cpp-master",

--- a/m3/tests/reporter_test.cc
+++ b/m3/tests/reporter_test.cc
@@ -44,6 +44,7 @@
 
 class ReporterTest : public ::testing::Test {
  protected:
+  // cppcheck-suppress unusedFunction
   virtual void SetUp() {
     server_ = std::shared_ptr<MockServer>(new MockServer("127.0.0.1", 0));
     thread_ = std::thread([this]() { server_->serve(); });
@@ -55,6 +56,7 @@ class ReporterTest : public ::testing::Test {
                     .Build();
   }
 
+  // cppcheck-suppress unusedFunction
   virtual void TearDown() {
     server_->stop();
     thread_.join();

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,5 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 def load_com_google_googletest():
-    native.http_archive(
+    http_archive(
         name = "com_google_googletest",
         strip_prefix = "googletest-ba96d0b1161f540656efdaed035b3c062b60e006",
         urls = [
@@ -8,9 +11,9 @@ def load_com_google_googletest():
     )
 
 def load_com_github_nelhage_rules_boost():
-    native.git_repository(
+    git_repository(
         name = "com_github_nelhage_rules_boost",
-        commit = "8cbc2be26be786d6f850fcf229dc06d158a79d81",
+        commit = "6d6fd834281cb8f8e758dd9ad76df86304bf1869",
         remote = "https://github.com/nelhage/rules_boost",
     )
 

--- a/tally/src/counter_impl.cc
+++ b/tally/src/counter_impl.cc
@@ -27,7 +27,7 @@ namespace tally {
 
 // cppcheck reports a false positive error that previous is not initialized.
 //
-// cppcheck-suppress uninitMemberVarPrivate
+// cppcheck-suppress uninitMemberVar
 CounterImpl::CounterImpl() noexcept : previous_(0), current_(0) {}
 
 void CounterImpl::Inc() noexcept { Inc(1); }

--- a/tally/src/counter_impl.cc
+++ b/tally/src/counter_impl.cc
@@ -27,7 +27,7 @@ namespace tally {
 
 // cppcheck reports a false positive error that previous is not initialized.
 //
-// cppcheck-suppress unusedFunction
+// cppcheck-suppress uninitMemberVarPrivate
 CounterImpl::CounterImpl() noexcept : previous_(0), current_(0) {}
 
 void CounterImpl::Inc() noexcept { Inc(1); }

--- a/tally/src/counter_impl.cc
+++ b/tally/src/counter_impl.cc
@@ -25,6 +25,9 @@
 
 namespace tally {
 
+// cppcheck reports a false positive error that previous is not initialized.
+//
+// cppcheck-suppress unusedFunction
 CounterImpl::CounterImpl() noexcept : previous_(0), current_(0) {}
 
 void CounterImpl::Inc() noexcept { Inc(1); }


### PR DESCRIPTION
In newer versions of Bazel (>= 0.20 as best as I can tell) the native `http_archive`
and `git_repository` rules are disabled by default. Consequently, this commit
updates `repositories.bzl` to explicitly load the rules and updates the calls to
them accordingly. I also took this oppurtunity to clean up the README.

Fixes #3.